### PR TITLE
[IMP] Field Services Report

### DIFF
--- a/reports/project_report_views.xml
+++ b/reports/project_report_views.xml
@@ -5,10 +5,10 @@
              <h6>
                 Task ID: #<span t-field="doc.id"/>
             </h6>
-        </xpath>
+        </xpath>      
         <xpath expr="//div[@class='page']//div[@class='row']//div[1]" position="replace">
           <div t-attf-class="{{'col-6' if report_type == 'pdf' else 'col-md-6 col-12'}}">
-                 <t t-set="index" t-value="0"/>
+                <t t-set="index" t-value="0"/>
                 <t t-foreach="doc.user_ids" t-as="user"> 
                     <div class="mb-3">
                         <div><strong>Worker: </strong></div>
@@ -26,7 +26,6 @@
                 </div>
         </xpath>  
     </template>
-
     <template id="timesheet_custom_page_service" inherit_id="hr_timesheet.timesheet_project_task_page">
         <xpath expr="//t[@t-if='doc.allow_timesheets and doc.timesheet_ids']//h2" position="before">
              <h6>

--- a/reports/project_report_views.xml
+++ b/reports/project_report_views.xml
@@ -6,6 +6,25 @@
                 Task ID: #<span t-field="doc.id"/>
             </h6>
         </xpath>
+        <xpath expr="//div[@class='page']//div[@class='row']//div[1]" position="replace">
+          <div t-attf-class="{{'col-6' if report_type == 'pdf' else 'col-md-6 col-12'}}">
+                 <t t-set="index" t-value="0"/>
+                <t t-foreach="doc.user_ids" t-as="user"> 
+                    <div class="mb-3">
+                        <div><strong>Worker: </strong></div>
+                        <div t-out="user" t-options='{
+                            "widget": "contact",
+                            "fields": ["name"]}'
+                        />
+                        <t t-if="index == 0">
+                            <div>+243 991 473 328</div>
+                            <div>sav@goshop.energy</div>
+                        </t>
+                        <t t-set="index" t-value="index + 1"/>
+                    </div>
+                </t>
+                </div>
+        </xpath>  
     </template>
 
     <template id="timesheet_custom_page_service" inherit_id="hr_timesheet.timesheet_project_task_page">


### PR DESCRIPTION
## Rationales

We aim to enhance the clarity and privacy of information on Field Service reports by displaying the worker's name, while concealing their email and phone number, and setting specific values for those fields.

To customize Field Service reports to display the worker's name, email, and phone number, while ensuring that only the worker's name is visible, with the email and phone number being set to specific values.



## Specification

   - Worker's Name: The worker's name should be displayed on the report.

   - Email: The email displayed on the report should be set to a specific email address, which is "sav@goshop.energy."

   - Phone Number: The phone number displayed on the report should be set to a specific contact number, which is "+243 991 473 328."

   - If multiple worker, phone and email only on the first one

![image](https://github.com/GoShop-Energy/field-service/assets/95297251/fbc13ee9-bc68-4d45-98a0-872a612c1f70)

